### PR TITLE
Make things more flexible

### DIFF
--- a/src/com/gfredericks/all_my_files_should_end_with_exactly_one_newline_character.clj
+++ b/src/com/gfredericks/all_my_files_should_end_with_exactly_one_newline_character.clj
@@ -1,4 +1,4 @@
-(ns gfredericks.all-my-files-should-end-with-exactly-one-newline-character
+(ns com.gfredericks.all-my-files-should-end-with-exactly-one-newline-character
   "Lint clojure files for file-ending newlines.")
 
 (defn ^:private scan

--- a/src/gfredericks/all_my_files_should_end_with_exactly_one_newline_character.clj
+++ b/src/gfredericks/all_my_files_should_end_with_exactly_one_newline_character.clj
@@ -2,35 +2,46 @@
   "Lint clojure files for file-ending newlines.")
 
 (defn ^:private scan
-  [files]
+  [files expected-newline-count]
+  {:pre [(#{0 1} expected-newline-count)]}
   (for [file files
         :let [contents (slurp file)
               [_ everything-but final-newlines] (re-matches #"(?s)(.*?)(\n*)"
-                                                            contents)]
-        :when (not= 1 (count final-newlines))]
+                                                            contents)
+              final-newline-count (count final-newlines)]
+        :when (not= final-newline-count expected-newline-count)]
     {:file file
-     :newline-count (count final-newlines)
-     :fixed (str everything-but "\n")}))
+     :newline-count final-newline-count
+     :fixed (str everything-but (when (= 1 expected-newline-count)
+                                  "\n"))}))
 
 (defn but-do-they?
-  [files]
-  (if-let [bad-files (seq (scan files))]
+  [files & {:keys [expected-newline-count]
+            :or {expected-newline-count 1}}]
+  {:pre [(#{0 1} expected-newline-count)]}
+  (if-let [bad-files (seq (scan files expected-newline-count))]
     (do
       (binding [*out* *err*]
-        (println "No, your files don't all end with exactly one newline character:")
+        (if (= 1 expected-newline-count)
+          (println "No, your files don't all end with exactly one newline character:")
+          (println "No, your files don't all end without a newline character:"))
         (doseq [{:keys [file newline-count]} bad-files]
           (printf "  - %s ends in %d newline characters\n" file newline-count))
         (flush))
       (count bad-files))
     (do
-      (println "Yes, all your files end with exactly one newline character.")
+      (if (= 1 expected-newline-count)
+        (println "Yes, all your files end with exactly one newline character.")
+        (println "Yes, all your files end without a newline character."))
       0)))
 
 (defn so-fix-them
-  [files]
-  (if-let [bad-files (seq (scan files))]
+  [files & {:keys [expected-newline-count]
+            :or {expected-newline-count 1}}]
+  {:pre [(#{0 1} expected-newline-count)]}
+  (if-let [bad-files (seq (scan files expected-newline-count))]
     (do
-      (doseq [{:keys [file fixed]} (seq (scan files))]
+      (doseq [{:keys [file fixed]} (seq (scan files expected-newline-count))]
         (spit file fixed)
         (printf "Fixed newlines in %s.\n" file))
       (flush))

--- a/src/gfredericks/all_my_files_should_end_with_exactly_one_newline_character.clj
+++ b/src/gfredericks/all_my_files_should_end_with_exactly_one_newline_character.clj
@@ -1,0 +1,37 @@
+(ns gfredericks.all-my-files-should-end-with-exactly-one-newline-character
+  "Lint clojure files for file-ending newlines.")
+
+(defn ^:private scan
+  [files]
+  (for [file files
+        :let [contents (slurp file)
+              [_ everything-but final-newlines] (re-matches #"(?s)(.*?)(\n*)"
+                                                            contents)]
+        :when (not= 1 (count final-newlines))]
+    {:file file
+     :newline-count (count final-newlines)
+     :fixed (str everything-but "\n")}))
+
+(defn but-do-they?
+  [files]
+  (if-let [bad-files (seq (scan files))]
+    (do
+      (binding [*out* *err*]
+        (println "No, your files don't all end with exactly one newline character:")
+        (doseq [{:keys [file newline-count]} bad-files]
+          (printf "  - %s ends in %d newline characters\n" file newline-count))
+        (flush))
+      (count bad-files))
+    (do
+      (println "Yes, all your files end with exactly one newline character.")
+      0)))
+
+(defn so-fix-them
+  [files]
+  (if-let [bad-files (seq (scan files))]
+    (do
+      (doseq [{:keys [file fixed]} (seq (scan files))]
+        (spit file fixed)
+        (printf "Fixed newlines in %s.\n" file))
+      (flush))
+    (println "All newlines are good, nothing to fix.")))

--- a/src/leiningen/all_my_files_should_end_with_exactly_one_newline_character.clj
+++ b/src/leiningen/all_my_files_should_end_with_exactly_one_newline_character.clj
@@ -52,7 +52,9 @@ USAGE:
   (let [all-files (all-files project)]
     (case (first args)
       ("but-do-they?" "check") (main/exit (core/but-do-they? all-files))
-      ("so-fix-them"  "fix")   (core/so-fix-them  all-files)
+      ("so-fix-them"  "fix")   (core/so-fix-them all-files)
+      "check-zero"             (main/exit (core/but-do-they? all-files :expected-newline-count 0))
+      "fix-zero"               (core/so-fix-them all-files :expected-newline-count 0)
       (do
         (println usage)
         (main/exit 1)))))

--- a/src/leiningen/all_my_files_should_end_with_exactly_one_newline_character.clj
+++ b/src/leiningen/all_my_files_should_end_with_exactly_one_newline_character.clj
@@ -2,7 +2,7 @@
   "Lint clojure files for file-ending newlines."
   (:require
    [clojure.java.io :as io]
-   [gfredericks.all-my-files-should-end-with-exactly-one-newline-character :as core]
+   [com.gfredericks.all-my-files-should-end-with-exactly-one-newline-character :as core]
    [leiningen.core.main :as main]))
 
 ;; next four functions are pasted from cljfmt

--- a/src/leiningen/all_my_files_should_end_with_exactly_one_newline_character.clj
+++ b/src/leiningen/all_my_files_should_end_with_exactly_one_newline_character.clj
@@ -1,41 +1,9 @@
 (ns leiningen.all-my-files-should-end-with-exactly-one-newline-character
   "Lint clojure files for file-ending newlines."
   (:require
-   [clojure.java.io     :as io]
+   [clojure.java.io :as io]
+   [gfredericks.all-my-files-should-end-with-exactly-one-newline-character :as core]
    [leiningen.core.main :as main]))
-
-(defn ^:private scan
-  [files]
-  (for [file files
-        :let [contents (slurp file)
-              [_ everything-but final-newlines] (re-matches #"(?s)(.*?)(\n*)"
-                                                            contents)]
-        :when (not= 1 (count final-newlines))]
-    {:file file
-     :newline-count (count final-newlines)
-     :fixed (str everything-but "\n")}))
-
-(defn ^:private but-do-they?
-  [files]
-  (if-let [bad-files (seq (scan files))]
-    (do
-      (binding [*out* *err*]
-        (println "No, your files don't all end with exactly one newline character:")
-        (doseq [{:keys [file newline-count]} bad-files]
-          (printf "  - %s ends in %d newline characters\n" file newline-count))
-        (flush))
-      (main/exit (count bad-files)))
-    (println "Yes, all your files end with exactly one newline character.")))
-
-(defn ^:private so-fix-them
-  [files]
-  (if-let [bad-files (seq (scan files))]
-    (do
-      (doseq [{:keys [file fixed]} (seq (scan files))]
-        (spit file fixed)
-        (printf "Fixed newlines in %s.\n" file))
-      (flush))
-    (println "All newlines are good, nothing to fix.")))
 
 ;; next four functions are pasted from cljfmt
 
@@ -71,7 +39,7 @@
   "USAGE: lein all-my-files-should-end-with-exactly-one-newline-character [but-do-they? | so-fix-them]")
 
 (defn all-my-files-should-end-with-exactly-one-newline-character
-  "Lint clojure file-ending newmlines.
+  "Lint clojure file-ending newlines.
 
 USAGE:
 
@@ -83,8 +51,8 @@ USAGE:
   [project & args]
   (let [all-files (all-files project)]
     (case (first args)
-      ("but-do-they?" "check") (but-do-they? all-files)
-      ("so-fix-them"  "fix")   (so-fix-them  all-files)
+      ("but-do-they?" "check") (main/exit (core/but-do-they? all-files))
+      ("so-fix-them"  "fix")   (core/so-fix-them  all-files)
       (do
         (println usage)
         (main/exit 1)))))


### PR DESCRIPTION
* Extract the core functionality to a standalone namespace, as we did in https://github.com/gfredericks/how-to-ns/pull/7
* Implement funcionality (programmatic + lein-invokable) to check/ensure file endings with _no_ newline. I don't encourage that style, but some people do use it and lein-all-my-files-should-end-with-exactly-one-newline-character would make our lives easier.

Cheers - Victor